### PR TITLE
Use supported header function

### DIFF
--- a/lib/private/log-request.middleware.js
+++ b/lib/private/log-request.middleware.js
@@ -91,8 +91,14 @@ module.exports = function logRequest(req, res, next) {
     report.statusCode = +res.statusCode;
 
     // Add response headers to the report.
-    // (note that this is not a documented thing and should not be relied upon!!!!)
-    report.responseHeaders = res._headers;
+    report.responseHeaders = {
+      'x-exit': res.get('x-exit'),
+      'x-exit-friendly-name': res.get('x-exit-friendly-name'),
+      'x-exit-description': res.get('x-exit-description'),
+      'x-exit-extended-description': res.get('x-exit-extended-description'),
+      'x-exit-more-info-url': res.get('x-exit-more-info-url'),
+      'x-exit-view-template-path': res.get('x-exit-view-template-path')
+    }
 
     // Save user session as embedded JSON to keep a permanent record
     report.userSession = _.cloneDeep(req.session);


### PR DESCRIPTION
Use the supported sails function to get the heard and populate the used headers in the report.responseHeaders object.