### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/private/log-request.middleware.js
+++ b/lib/private/log-request.middleware.js
@@ -92,7 +92,7 @@ module.exports = function logRequest(req, res, next) {
 
     // Add response headers to the report.
     // (note that this is not a documented thing and should not be relied upon!!!!)
-    report.responseHeaders = res._headers;
+    report.responseHeaders = res.getHeaders();
 
     // Save user session as embedded JSON to keep a permanent record
     report.userSession = _.cloneDeep(req.session);


### PR DESCRIPTION
`OutgoingMessage.prototype._headers` is deprecated, and gives a warning when the server receives a request. Switching to `OutgoingMessage.prototype.getHeaders()` resolves this.


https://nodejs.org/docs/latest-v14.x/api/deprecations.html#deprecations_dep0066_outgoingmessage_prototype_headers_outgoingmessage_prototype_headernames